### PR TITLE
Fix docs, typos, CI, and fpm Dockerfile (README, supervisor comments, checkout v4, LICENSE year, librabbitmq-dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         image-variant: [ 'franken', 'apache', 'cli', 'fpm', 'supervisor', 'dev', 'supervisor-franken' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2024 Roni Saha
+Copyright (c) 2022-2026 Roni Saha
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -24,12 +24,17 @@ All image contain following php extension and [composer](https://github.com/comp
 - curl
 - exif
 - iconv
+- xsl
+- soap
+- pgsql
+- igbinary
+- mongodb
 - xdebug(Only in cli and dev variant)
 
 ## Image Variants
 
 ### php-8-debian:cli or php-8-debian:cli-{php-version}
-This use the cli base image with xdebug enabled, also contain nodejs-20.x and npm
+This use the cli base image with xdebug enabled, also contain nodejs-24.x and npm
 
 ### php-8-debian:fpm or php-8-debian:fpm-{php-version}
 This use the fpm base image
@@ -46,5 +51,5 @@ This use the cli base image and set supervisor as entry point. Mount any supervi
 ### php-8-debian:franken or php-8-debian:franken-{php-version}
 This use the dunglas/frankenphp base image
 
-### php-8-debian:franken or php-8-debian:supervisor-franken-{php-version}
+### php-8-debian:supervisor-franken or php-8-debian:supervisor-franken-{php-version}
 This use the dunglas/frankenphp base image with github.com/baldinof/caddy-supervisor module

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -13,7 +13,7 @@ RUN set -eux; \
         libyaml-dev \
         gettext graphviz \
         libmagickwand-dev \
-        librabbitmq-dev\
+        librabbitmq-dev \
         libpq-dev  \
         libxslt1-dev \
         \

--- a/supervisor-oci/Dockerfile
+++ b/supervisor-oci/Dockerfile
@@ -106,6 +106,6 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
-#Make supervisor ad entrypoint
+# Make supervisor as entrypoint
 ENTRYPOINT ["/usr/bin/supervisord"]
 CMD ["-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -86,6 +86,6 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
-#Make supervisor ad entrypoint
+# Make supervisor as entrypoint
 ENTRYPOINT ["/usr/bin/supervisord"]
 CMD ["-c", "/etc/supervisor/supervisord.conf", "-n"]


### PR DESCRIPTION
## Summary

Small fixes across docs, Dockerfiles, CI, and license: README accuracy, supervisor entrypoint comments, fpm package line, GitHub Actions checkout, and LICENSE year.

## Changes

### Dockerfile

- **fpm/Dockerfile**: Add missing space before backslash in `librabbitmq-dev \` so the line continuation is correct and `apt-get` does not try to install a wrong package.
- **supervisor/Dockerfile** & **supervisor-oci/Dockerfile**: Fix comment typo "ad entrypoint" → "as entrypoint" (`# Make supervisor as entrypoint`).

### Documentation (README)

- **Supervisor-franken heading**: Correct line 48 from `php-8-debian:franken or ... supervisor-franken-{php-version}` to `php-8-debian:supervisor-franken or php-8-debian:supervisor-franken-{php-version}` so the first tag matches the variant.
- **Node.js version**: Update CLI description from "nodejs-20.x" to "nodejs-24.x" to match `cli/Dockerfile` (NODE_MAJOR=24).
- **Extensions list**: Add xsl, soap, pgsql, igbinary, and mongodb so the README matches the extensions installed in the images.

### CI

- **GitHub Actions**: Bump `actions/checkout` from `v3` to `v4` in `.github/workflows/docker-publish.yml`.

### License

- **LICENSE**: Update copyright year from "2022-2024" to "2022-2026".
